### PR TITLE
Automate db seed task with Knex

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+  development: {
+    client: 'pg',
+    connection: {
+      host: '127.0.0.1',
+      user: 'postgres',
+      password: process.env.PG_PASS,
+      database: 'steam_reviews'
+    },
+    migrations: {
+      directory: path.resolve(__dirname, 'server', 'db', 'migrations')
+    },
+    seeds: {
+      directory: path.resolve(__dirname, 'server', 'db', 'seeds')
+    }
+  },
+  production: {
+    client: 'pg',
+    connection: process.env.PGDB_URI,
+    migrations: {
+      directory: path.resolve(__dirname, 'server', 'db', 'migrations')
+    },
+    seeds: {
+      directory: path.resolve(__dirname, 'server', 'db', 'seeds', 'production')
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Reviews module for Steam app clone",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "seed": "knex migrate:rollback && knex migrate:latest && knex seed:run",
     "server-dev": "nodemon server/index.js",
     "client-dev": "webpack-dev-server --mode development --hot --open",
     "lint": "eslint client/** --fix",

--- a/server/db/copyToTable.js
+++ b/server/db/copyToTable.js
@@ -1,0 +1,24 @@
+const { promisify } = require('util');
+const stream = require('stream');
+const copyFrom = require('pg-copy-streams').from;
+const pipeline = promisify(stream.pipeline);
+
+/**
+ * Copies readableStream into Postgres tableName using txOrKnex connection pooling
+ * @param {Object} txOrKnex
+ * @param {String} tableName
+ * @param {Array} cols: Explicitly list which columns to copy csv data into
+ * @param {Stream} readableStream
+ */
+exports.copyToTable = async (txOrKnex, tableName, cols, readableStream) => {
+  const knexClient = await (txOrKnex.trxClient || txOrKnex.client);
+  const pgClient = await knexClient.acquireConnection();
+  try {
+    await pipeline(
+      readableStream,
+      pgClient.query(copyFrom(`COPY ${tableName} (${cols.join(',')}) FROM STDIN DELIMITER ',' CSV HEADER`))
+    );
+  } finally {
+    await knexClient.releaseConnection(pgClient);
+  }
+};

--- a/server/db/knex.js
+++ b/server/db/knex.js
@@ -1,0 +1,3 @@
+const environment = process.env.NODE_ENV || 'development';
+const config = require('../../knexfile')[environment];
+module.exports = require('knex')(config);

--- a/server/db/legacy_seed.sql
+++ b/server/db/legacy_seed.sql
@@ -1,3 +1,6 @@
+-- NOTE: This is a legacy file. Seeding is now being handled by knex
+-- migrations & seeds functionalities (in /server/db)
+
 -- Before running seed script:
 -- 1. Ensure PostgreSQL service is running on port 5432
 -- 2. Run 'CREATE DATABASE steam_reviews'
@@ -54,6 +57,7 @@ CREATE TABLE reviews (
   num_comments SMALLINT
 );
 
+/*
 -- TODO: Badge URLs might need to be hosted in media bucket instead of taken from lorem picsum site. Wait for answer from TM's.
 INSERT INTO badges (title, xp, badge_url)
   VALUES
@@ -112,3 +116,4 @@ COPY reviews(
 FROM '/mnt/c/Users/Christina Wang/Documents/Coding/hack-reactor/front-end-capstone/steam-reviews/data-gen/csv-seeds/reviews.csv'
 DELIMITER ','
 CSV HEADER;
+*/

--- a/server/db/migrations/20200619145203_create_badges_table.js
+++ b/server/db/migrations/20200619145203_create_badges_table.js
@@ -1,0 +1,15 @@
+// Migrated straight from legacy seed.sql file, thus using .raw to not rewrite anything
+exports.up = function (knex) {
+  return knex.raw(
+    'CREATE TABLE badges (' +
+      'id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,' +
+      'title VARCHAR(50),' +
+      'xp SMALLINT,' +
+      'badge_url TEXT' +
+    ')'
+  );
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable('badges');
+};

--- a/server/db/migrations/20200619145512_create_users_table.js
+++ b/server/db/migrations/20200619145512_create_users_table.js
@@ -1,0 +1,22 @@
+// Migrated straight from legacy seed.sql file, thus using .raw to not rewrite anything
+exports.up = function (knex) {
+  return knex.raw(
+    'CREATE TABLE users(' +
+      'id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,' +
+      'username VARCHAR(50),' +
+      'profile_url TEXT,' +
+      'is_online BOOLEAN,' +
+      'num_products SMALLINT,' +
+      'num_reviews SMALLINT,' +
+      'steam_level SMALLINT,' +
+      'id_badge INTEGER REFERENCES badges(id),' +
+      'is_in_game BOOLEAN,' +
+      'in_game_id INTEGER CONSTRAINT game_id_range CHECK(in_game_id >= 1 AND in_game_id <= 100),' +
+      'in_game_status TEXT' +
+    ');'
+  );
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable('users');
+};

--- a/server/db/migrations/20200619145709_create_reviews_table.js
+++ b/server/db/migrations/20200619145709_create_reviews_table.js
@@ -1,0 +1,24 @@
+// Migrated straight from legacy seed.sql file, thus using .raw to not rewrite anything
+exports.up = function(knex) {
+  return knex.raw(
+    'CREATE TABLE reviews(' +
+      'id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,' +
+      'id_user INTEGER REFERENCES users(id),' +
+      'id_game INTEGER NOT NULL CONSTRAINT game_id_range CHECK(id_game >= 1 AND id_game <= 100),' +
+      'is_recommended BOOLEAN,' +
+      'hours_on_record NUMERIC(5, 1),' +
+      'hours_at_review_time NUMERIC(5, 1) CHECK(hours_at_review_time <= hours_on_record),' +
+      'purchase_type VARCHAR(10) CHECK (purchase_type IN (\'direct\', \'key\')),' +
+      'date_posted DATE,' +
+      'received_free BOOLEAN,' +
+      'review_text TEXT,' +
+      'num_found_helpful SMALLINT,' +
+      'num_found_funny SMALLINT,' +
+      'num_comments SMALLINT' +
+    ');'
+  );
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('reviews');
+};

--- a/server/db/seeds/01_badges.js
+++ b/server/db/seeds/01_badges.js
@@ -1,0 +1,83 @@
+/* eslint-disable camelcase */
+const badgeUrls = require('../hostedUrls.json').badges;
+
+let insertArray = [
+  {
+    title: 'Product Registration',
+    xp: 100
+  },
+  {
+    title: 'Pillar of Community',
+    xp: 100
+  },
+  {
+    title: 'Community Ambassador',
+    xp: 200
+  },
+  {
+    title: 'Community Leader',
+    xp: 500
+  },
+  {
+    title: '1 Year of Service',
+    xp: 50
+  },
+  {
+    title: '2 Years of Service',
+    xp: 100
+  },
+  {
+    title: '3 Years of Service',
+    xp: 150
+  },
+  {
+    title: '4 Years of Service',
+    xp: 200
+  },
+  {
+    title: '5 Years of Service',
+    xp: 250
+  },
+  {
+    title: 'One-Stop Shopper',
+    xp: 100
+  },
+  {
+    title: 'Select Collector',
+    xp: 125
+  },
+  {
+    title: 'Adept Accumulator',
+    xp: 150
+  },
+  {
+    title: 'Sharp-Eyed Stockpiler',
+    xp: 200
+  },
+  {
+    title: 'Collection Agent',
+    xp: 250
+  },
+  {
+    title: 'Power Player',
+    xp: 325
+  },
+  {
+    title: 'Game Mechanic',
+    xp: 500
+  }
+];
+
+insertArray = insertArray.map((row, idx) => ({
+  ...row,
+  badge_url: badgeUrls[idx]
+}));
+
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex('badges').del()
+    .then(() => {
+      // Inserts seed entries (16 total)
+      return knex('badges').insert(insertArray);
+    });
+};

--- a/server/db/seeds/02_users.js
+++ b/server/db/seeds/02_users.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const { copyToTable } = require('../copyToTable');
+
+exports.seed = function(knex) {
+  // Deletes ALL existing entries
+  return knex('users').del()
+    .then(() => {
+      // Inserts seed entries from generated .csv data
+      return knex.transaction(async (trx) => {
+        const fileStream = fs.createReadStream(path.resolve(__dirname, '..', '..', '..', 'data-gen', 'csv-seeds', 'users.csv'));
+        try {
+          await copyToTable(
+            trx,
+            'users',
+            [
+              'username',
+              'profile_url',
+              'is_online',
+              'num_products',
+              'num_reviews',
+              'steam_level',
+              'id_badge',
+              'is_in_game',
+              'in_game_id',
+              'in_game_status'
+            ],
+            fileStream
+          );
+        } catch (e) {
+          console.error(e);
+        }
+      });
+    });
+};

--- a/server/db/seeds/03_reviews.js
+++ b/server/db/seeds/03_reviews.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const { copyToTable } = require('../copyToTable');
+
+exports.seed = function (knex) {
+  // Deletes ALL existing entries
+  return knex('reviews').del()
+    .then(() => {
+      // Inserts seed entries from generated .csv data
+      return knex.transaction(async (trx) => {
+        const fileStream = fs.createReadStream(path.resolve(__dirname, '..', '..', '..', 'data-gen', 'csv-seeds', 'reviews.csv'));
+        try {
+          await copyToTable(
+            trx,
+            'reviews',
+            [
+              'id_user',
+              'id_game',
+              'is_recommended',
+              'hours_on_record',
+              'hours_at_review_time',
+              'purchase_type',
+              'date_posted',
+              'received_free',
+              'review_text',
+              'num_found_helpful',
+              'num_found_funny',
+              'num_comments'
+            ],
+            fileStream
+          );
+        } catch (e) {
+          console.error(e);
+        }
+      });
+    });
+};


### PR DESCRIPTION
### Functionality update:
Before, db seeding had to be done manually by piping seed.sql into Postgres via CLI (psql), but now the task is automated with KnexJS (and my machine-specific path strings in seed.sql aren't necessary anymore, meaning anyone can seed their database without changing the seed.sql file).

Now, all that needs to be done to seed the database is run `npm run seed` or `yarn seed`.

### Details:
The 6 scripts in migrations & seeds directories have function & file names auto-generated by Knex. Running `knex migrate:rollback` calls all the `exports.down` functions, `knex migrate:latest` calls exports.up. These functions are called based on the order of the files in the migrations directory to ensure tables are inserted in proper order.

`knex seed:run` calls exports.seed functions in filename order, ensuring data is seeded in proper order.

These three Knex scripts are packaged together in the seed script in `package.json`.

The util `copyToTable` pipes the contents of the .csv seed data files into Postgres tables directly via ReadableStream.

Ticket: https://trello.com/c/m7T5paAE/42-m-write-scripts-to-allow-knexjs-to-seed-db-through-packagejson

@damienmjones Thanks for your help!